### PR TITLE
return 404 status code when dpid is not found

### DIFF
--- a/main.py
+++ b/main.py
@@ -75,6 +75,9 @@ class Main(KytosNApp):
         else:
             switches = [self.controller.get_switch_by_dpid(dpid)]
 
+        if None in switches:
+            return jsonify({"reponse": "dpid not found"}), 404
+
         for switch in switches:
             serializer = self._get_flow_serializer(switch)
             flows = flows_dict.get('flows', [])


### PR DESCRIPTION
This PR fixes the first item of issue #23. 

The error without this PR is, which could happen also when the switch got disconnected and a flow_mod is sent:

```
Traceback (most recent call last):
  File "/home/arcanjo/repos/kytos/.direnv/python-3.6.4/lib/python3.6/site-packages/flask/app.py", line 1982, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/arcanjo/repos/kytos/.direnv/python-3.6.4/lib/python3.6/site-packages/flask/app.py", line 1614, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/arcanjo/repos/kytos/.direnv/python-3.6.4/lib/python3.6/site-packages/flask_cors/extension.py", line 161, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
  File "/home/arcanjo/repos/kytos/.direnv/python-3.6.4/lib/python3.6/site-packages/flask/app.py", line 1517, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/home/arcanjo/repos/kytos/.direnv/python-3.6.4/lib/python3.6/site-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/home/arcanjo/repos/kytos/.direnv/python-3.6.4/lib/python3.6/site-packages/flask/app.py", line 1612, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/arcanjo/repos/kytos/.direnv/python-3.6.4/lib/python3.6/site-packages/flask/app.py", line 1598, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/arcanjo/repos/kytos/.direnv/python-3.6.4/var/lib/kytos/napps/kytos/flow_manager/main.py", line 59, in add
    return self._send_flow_mods_from_request(dpid, "add")
  File "/home/arcanjo/repos/kytos/.direnv/python-3.6.4/var/lib/kytos/napps/kytos/flow_manager/main.py", line 80, in _send_flow_mods_from_request
    serializer = self._get_flow_serializer(switch)
  File "/home/arcanjo/repos/kytos/.direnv/python-3.6.4/var/lib/kytos/napps/kytos/flow_manager/main.py", line 117, in _get_flow_serializer
    version = switch.connection.protocol.version
AttributeError: 'NoneType' object has no attribute 'connection'
``` 