### PR TITLE
Listen to OpenFlow errors sent by of_core.

### DIFF
--- a/main.py
+++ b/main.py
@@ -163,7 +163,8 @@ class Main(KytosNApp):
         """
         xid = event.content["message"].header.xid.value
         try:
-            flow = self.flow_mods_sent[xid]
-            self._send_napp_event(flow.switch, flow, 'error')
+            flow = self._flow_mods_sent[xid]
         except KeyError:
             pass
+        else:
+            self._send_napp_event(flow.switch, flow, 'error')

--- a/settings.py
+++ b/settings.py
@@ -1,3 +1,4 @@
 """Settings from flow_manager NApp."""
 # Pooling frequency
 STATS_INTERVAL = 30
+FLOWS_DICT_MAX_SIZE = 10000

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,51 @@
+"""Module to test the main napp file."""
+from unittest import TestCase
+from unittest.mock import Mock
+
+from kytos.core import Controller
+from kytos.core.config import KytosConfig
+
+from napps.kytos.flow_manager.main import Main
+
+
+class TestMain(TestCase):
+    """Test the Main class."""
+
+    def setUp(self):
+        """Execute steps before each tests.
+        """
+        self.napp = Main(self.get_controller_mock())
+
+    @staticmethod
+    def get_controller_mock():
+        """Return a controller mock."""
+        options = KytosConfig().options['daemon']
+        controller = Controller(options)
+        controller.log = Mock()
+        return controller
+
+    def test_add_flow_mod_sent_ok(self):
+        self.napp._flow_mods_sent_max_size = 3
+        flow = Mock()
+        xid = '12345'
+        initial_len = len(self.napp._flow_mods_sent)
+        self.napp._add_flow_mod_sent(xid, flow)
+
+        assert len(self.napp._flow_mods_sent) == initial_len + 1
+        assert self.napp._flow_mods_sent.get(xid, None) == flow
+
+    def test_add_flow_mod_sent_overlimit(self):
+        self.napp._flow_mods_sent_max_size = 5
+        xid = '23456'
+        while len(self.napp._flow_mods_sent) < 5:
+            xid += '1'
+            flow = Mock()
+            self.napp._add_flow_mod_sent(xid, flow)
+
+        xid = '90876'
+        flow = Mock()
+        initial_len = len(self.napp._flow_mods_sent)
+        self.napp._add_flow_mod_sent(xid, flow)
+
+        assert len(self.napp._flow_mods_sent) == initial_len
+        assert self.napp._flow_mods_sent.get(xid, None) == flow

--- a/tox.ini
+++ b/tox.ini
@@ -4,15 +4,22 @@ envlist = coverage,lint
 
 [testenv]
 whitelist_externals = rm
+                      git
+                      mkdir
+                      cd
 deps = -Urrequirements/dev.txt
 setenv=
     PYTHONPATH = {toxworkdir}/py36/var/lib/kytos/:{envdir}
+
 
 
 [testenv:coverage]
 skip_install = true
 envdir = {toxworkdir}/py36
 commands=
+    mkdir -p napps/kytos
+    rm -fr napps/kytos/of_core
+    git clone https://github.com/kytos/of_core.git napps/kytos/of_core
     ; Force packaging even if setup.{py,cfg} haven't changed
     rm -rf ./*.egg-info/
     python setup.py coverage


### PR DESCRIPTION
If the error is related to a flow mod sent by flow_manager, generate
a new event to the caller application. Fix #73.