### PR TITLE
Fix handle_errors method test

### DIFF
--- a/main.py
+++ b/main.py
@@ -171,5 +171,5 @@ class Main(KytosNApp):
         except KeyError:
             pass
         else:
-            self._send_napp_event(flow.switch, flow, 'error', 
-                                  error_type=error_type, error_code=error_code)                             
+            self._send_napp_event(flow.switch, flow, 'error',
+                                  error_type=error_type, error_code=error_code)                    

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -172,8 +172,12 @@ class TestMain(TestCase):
 
         message = MagicMock()
         message.header.xid.value = 0
+        message.error_type = 'type'
+        message.code = 123
         event = get_kytos_event_mock(name='.*.of_core.*.ofpt_error',
                                      content={'message': message})
         self.napp.handle_errors(event)
 
-        mock_send_napp_event.assert_called_with(flow.switch, flow, 'error')
+        mock_send_napp_event.assert_called_with(flow.switch, flow, 'error',
+                                                error_type='type',
+                                                error_code=123)


### PR DESCRIPTION
Tests were failed because the assert was made without error_type and error_code. This commit solves this problem.