### PR TITLE
Add flow persistence

### DIFF
--- a/main.py
+++ b/main.py
@@ -47,11 +47,11 @@ class Main(KytosNApp):
         """Shutdown routine of the NApp."""
         log.debug("flow-manager stopping")
 
-    @listen_to('kytos/topology.port.created')
+    @listen_to('kytos/of_core.handshake.completed')
     def resend_stored_flows(self, event):
         """Resend stored Flows."""
-        dpid = str(event.content['switch'])
-        switch = self.controller.get_switch_by_dpid(dpid)
+        switch = event.content['switch']
+        dpid = str(switch.dpid)
         # This can be a problem because this code is running a thread
         if dpid in self.resent_flows:
             log.info(f'Flow already resended to Switch {dpid}')

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from flask import jsonify, request
 
 from kytos.core import KytosEvent, KytosNApp, log, rest
 from kytos.core.helpers import listen_to
+from napps.kytos.flow_manager.storehouse import StoreHouse
 from napps.kytos.of_core.flow import FlowFactory
 
 from .exceptions import InvalidCommandError
@@ -24,16 +25,113 @@ class Main(KytosNApp):
         self._flow_mods_sent = OrderedDict()
         self._flow_mods_sent_max_size = FLOWS_DICT_MAX_SIZE
 
+        # Storehouse client to save and restore flow data:
+        self.storehouse = StoreHouse(self.controller)
+
+        # Format of stored flow data:
+        # {'flow_persistence': {'dpid_str': {'flow_list': [
+        #                                     {'command': '<add|delete>',
+        #                                      'flow': {flow_dict}}]}}}
+        self.stored_flows = {}
+        self.resent_flows = set()
+
     def execute(self):
         """Run once on NApp 'start' or in a loop.
 
         The execute method is called by the run method of KytosNApp class.
         Users shouldn't call this method directly.
         """
+        self._load_flows()
 
     def shutdown(self):
         """Shutdown routine of the NApp."""
         log.debug("flow-manager stopping")
+
+    @listen_to('kytos/topology.port.created')
+    def resend_stored_flows(self, event):
+        """Resend stored Flows."""
+        dpid = str(event.content['switch'])
+        switch = self.controller.get_switch_by_dpid(dpid)
+        # This can be a problem because this code is running a thread
+        if dpid in self.resent_flows:
+            log.info(f'Flow already resended to Switch {dpid}')
+            return
+        if dpid in self.stored_flows:
+            flow_list = self.stored_flows[dpid]['flow_list']
+            for flow in flow_list:
+                command = flow['command']
+                flows_dict = {"flows": [flow['flow']]}
+                self._install_flows(command, flows_dict, [switch])
+            self.resent_flows.add(dpid)
+            log.info(f'Flows resent to Switch {dpid}')
+
+    # pylint: disable=attribute-defined-outside-init
+    def _load_flows(self):
+        """Load stored flows."""
+        try:
+            data = self.storehouse.get_data()['flow_persistence']
+            if 'id' in data:
+                del data['id']
+            self.stored_flows = data
+
+        except KeyError as error:
+            log.debug(f'There are no flows to load: {error}')
+        else:
+            log.info('Flows loaded.')
+
+    def _store_changed_flows(self, command, flow, switch):
+        """Store changed flows.
+
+        Args:
+            command: Flow command to be installed
+            flow: Flows to be stored
+            switch: Switch target
+        """
+        stored_flows_box = self.stored_flows.copy()
+        # if the flow has a destination dpid it can be stored.
+        if not switch:
+            log.info('The Flow cannot be stored, the destination switch '
+                     f'have not been specified: {switch}')
+            return
+
+        installed_flow = {}
+        flow_list = []
+        installed_flow['command'] = command
+        installed_flow['flow'] = flow
+
+        serializer = FlowFactory.get_class(switch)
+        installed_flow_obj = serializer.from_dict(flow, switch)
+
+        if switch.id not in stored_flows_box:
+            # Switch not stored, add to box.
+            flow_list.append(installed_flow)
+            stored_flows_box[switch.id] = {'flow_list': flow_list}
+        else:
+            stored_flows = stored_flows_box[switch.id].get('flow_list', [])
+            # Check if flow already stored
+            for stored_flow in stored_flows:
+                stored_flow_obj = serializer.from_dict(stored_flow['flow'],
+                                                       switch)
+                if installed_flow_obj == stored_flow_obj:
+                    if stored_flow['command'] == installed_flow['command']:
+                        log.debug('Data already stored.')
+                        return
+                    # Flow with inconsistency in "command" fields : Remove the
+                    # old instruction. This happens when there is a stored
+                    # instruction to install the flow, but the new instruction
+                    # is to remove it. In this case, the old instruction is
+                    # removed and the new one is stored.
+                    stored_flow['command'] = installed_flow.get('command')
+                    stored_flows.remove(stored_flow)
+                    break
+
+            stored_flows.append(installed_flow)
+            stored_flows_box[switch.id]['flow_list'] = stored_flows
+
+        stored_flows_box['id'] = 'flow_persistence'
+        self.storehouse.save_flow(stored_flows_box)
+        del stored_flows_box['id']
+        self.stored_flows = stored_flows_box.copy()
 
     @rest('v2/flows')
     @rest('v2/flows/<dpid>')
@@ -80,12 +178,12 @@ class Main(KytosNApp):
         switches = self.controller.switches.values()
         return [switch for switch in switches if switch.is_enabled()]
 
-    def _send_flow_mods_from_request(self, dpid, command):
+    def _send_flow_mods_from_request(self, dpid, command, flows_dict=None):
         """Install FlowsMods from request."""
-        flows_dict = request.get_json()
-
         if flows_dict is None:
-            return jsonify({"response": 'flows dict is none.'}), 404
+            flows_dict = request.get_json()
+            if flows_dict is None:
+                return jsonify({"response": 'flows dict is none.'}), 404
 
         if dpid:
             switch = self.controller.get_switch_by_dpid(dpid)
@@ -124,6 +222,7 @@ class Main(KytosNApp):
                 self._add_flow_mod_sent(flow_mod.header.xid, flow, command)
 
                 self._send_napp_event(switch, flow, command)
+                self._store_changed_flows(command, flow_dict, switch)
 
     def _add_flow_mod_sent(self, xid, flow, command):
         """Add the flow mod to the list of flow mods sent."""

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,33 +6,92 @@
 #
 -e git+git://github.com/kytos/kytos.git#egg=kytos
 -e git+git://github.com/kytos/python-openflow.git#egg=python-openflow
--e git+git://github.com/kytos/of_core.git#egg=of_core
+-e git+git://github.com/kytos/of_core.git#egg=kytos-of-core
 -e .
-astroid==2.2.5            # via pylint
-click==7.0                # via flask, pip-tools
-coverage==5.0.3
+alabaster==0.7.12         # via sphinx
+appdirs==1.4.3            # via virtualenv
+appnope==0.1.0            # via -r requirements/run.txt
+argh==0.26.2              # via sphinx-autobuild
+astroid==2.3.3            # via pylint
+attrs==19.3.0             # via pytest
+babel==2.8.0              # via sphinx
+backcall==0.1.0           # via -r requirements/run.txt, ipython
+certifi==2019.11.28       # via requests
+chardet==3.0.4            # via requests
+click==7.1.1              # via -r requirements/run.txt, flask, pip-tools
+coverage==5.0.4           # via -r requirements/dev.in
+decorator==4.4.2          # via -r requirements/run.txt, ipython, traitlets
+distlib==0.3.0            # via virtualenv
 docopt==0.6.2             # via yala
-filelock==3.0.10          # via tox
-flask==1.1.2
-isort==4.3.15             # via pylint, yala
-itsdangerous==1.1.0       # via flask
-jinja2==2.10              # via flask
-lazy-object-proxy==1.3.1  # via astroid
-markupsafe==1.1.1         # via jinja2
+docutils==0.16            # via -r requirements/run.txt, python-daemon, sphinx
+filelock==3.0.12          # via tox, virtualenv
+flask-cors==3.0.8         # via -r requirements/run.txt
+flask-socketio==4.2.1     # via -r requirements/run.txt
+flask==1.1.2              # via -r requirements/run.txt, flask-cors, flask-socketio
+idna==2.9                 # via requests
+imagesize==1.2.0          # via sphinx
+importlib-metadata==1.7.0  # via importlib-resources, pluggy, pytest, tox, virtualenv
+importlib-resources==1.5.0  # via virtualenv
+ipython-genutils==0.2.0   # via -r requirements/run.txt, traitlets
+ipython==7.13.0           # via -r requirements/run.txt
+isort==4.3.21             # via pylint, yala
+itsdangerous==1.1.0       # via -r requirements/run.txt, flask
+janus==0.4.0              # via -r requirements/run.txt
+jedi==0.16.0              # via -r requirements/run.txt, ipython
+jinja2==2.11.1            # via -r requirements/run.txt, flask, sphinx
+lazy-object-proxy==1.4.3  # via astroid
+livereload==2.6.1         # via sphinx-autobuild
+lockfile==0.12.2          # via -r requirements/run.txt, python-daemon
+markupsafe==1.1.1         # via -r requirements/run.txt, jinja2
 mccabe==0.6.1             # via pylint
-pip-tools==3.5.0
-pluggy==0.9.0             # via tox
-py==1.8.0                 # via tox
+more-itertools==8.2.0     # via pytest
+packaging==20.3           # via pytest, sphinx, tox
+parso==0.6.2              # via -r requirements/run.txt, jedi
+pathtools==0.1.2          # via -r requirements/run.txt, sphinx-autobuild, watchdog
+pexpect==4.8.0            # via -r requirements/run.txt, ipython
+pickleshare==0.7.5        # via -r requirements/run.txt, ipython
+pip-tools==4.5.1          # via -r requirements/dev.in
+pluggy==0.13.1            # via pytest, tox
+port_for==0.3.1           # via sphinx-autobuild
+prompt-toolkit==3.0.5     # via -r requirements/run.txt, ipython
+ptyprocess==0.6.0         # via -r requirements/run.txt, pexpect
+py==1.8.1                 # via pytest, tox
 pycodestyle==2.5.0        # via yala
-pydocstyle==3.0.0         # via yala
-pylint==2.3.1             # via yala
-pytest==5.4.1             # via pytest
-six==1.12.0               # via astroid, pip-tools, pydocstyle, tox
-snowballstemmer==1.2.1    # via pydocstyle
+pydocstyle==5.1.1         # via -r requirements/dev.in
+pygments==2.7.1           # via -r requirements/run.txt, ipython, sphinx
+pyjwt==1.7.1              # via -r requirements/run.txt
+pylint==2.4.4             # via yala
+pyparsing==2.4.6          # via packaging
+pytest==5.4.1             # via -r requirements/dev.in
+python-daemon==2.2.4      # via -r requirements/run.txt
+python-engineio==3.12.1   # via -r requirements/run.txt, python-socketio
+python-socketio==4.5.1    # via -r requirements/run.txt, flask-socketio
+pytz==2019.3              # via babel
+pyyaml==5.3.1             # via sphinx-autobuild
+requests==2.23.0          # via sphinx
+six==1.15.0               # via -r requirements/run.txt, astroid, flask-cors, livereload, packaging, pip-tools, python-engineio, python-socketio, tox, traitlets, virtualenv
+snowballstemmer==2.0.0    # via pydocstyle, sphinx
+sphinx-autobuild==0.7.1   # via kytos-sphinx-theme
+sphinx==2.0.1             # via kytos-sphinx-theme
+sphinxcontrib-applehelp==1.0.2  # via sphinx
+sphinxcontrib-devhelp==1.0.2  # via sphinx
+sphinxcontrib-htmlhelp==1.0.3  # via sphinx
+sphinxcontrib-jsmath==1.0.1  # via sphinx
+sphinxcontrib-qthelp==1.0.3  # via sphinx
+sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 toml==0.10.0              # via tox
-tox==3.7.0
-typed-ast==1.3.1          # via astroid
-virtualenv==16.4.3        # via tox
-werkzeug==1.0.1           # via flask
-wrapt==1.11.1             # via astroid
-yala==1.7.0
+tornado==6.0.4            # via livereload, sphinx-autobuild
+tox==3.14.6               # via -r requirements/dev.in
+traitlets==4.3.3          # via -r requirements/run.txt, ipython
+typed-ast==1.4.1          # via astroid
+urllib3==1.25.8           # via requests
+virtualenv==20.0.15       # via tox
+watchdog==0.10.2          # via -r requirements/run.txt, sphinx-autobuild
+wcwidth==0.1.9            # via -r requirements/run.txt, prompt-toolkit, pytest
+werkzeug==1.0.1           # via -r requirements/run.txt, flask
+wrapt==1.11.2             # via astroid
+yala==2.2.0               # via -r requirements/dev.in
+zipp==3.3.0               # via importlib-metadata, importlib-resources
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/settings.py
+++ b/settings.py
@@ -2,3 +2,5 @@
 # Pooling frequency
 STATS_INTERVAL = 30
 FLOWS_DICT_MAX_SIZE = 10000
+# Time (in seconds) to wait retrieve box from storehouse
+WAIT_PERSISTENCE_BOX_TIMER = 0.1

--- a/storehouse.py
+++ b/storehouse.py
@@ -1,0 +1,108 @@
+"""Module to handle the storehouse."""
+import time
+
+from kytos.core import log
+from kytos.core.events import KytosEvent
+from napps.kytos.flow_manager import settings
+
+DEFAULT_WAIT_PERSISTENCE_BOX_TIMER = 0.1
+
+
+class StoreHouse:
+    """Class to handle storehouse."""
+
+    @classmethod
+    def __new__(cls, *args, **kwargs):
+        # pylint: disable=unused-argument
+        """Make this class a Singleton."""
+        instance = cls.__dict__.get("__instance__")
+        if instance is not None:
+            return instance
+        cls.__instance__ = instance = object.__new__(cls)
+        return instance
+
+    def __init__(self, controller):
+        """Create a storehouse client instance."""
+        self.controller = controller
+        self.namespace = 'kytos.flow.persistence'
+        self.wait_persistence_box = getattr(settings,
+                                            'WAIT_PERSISTENCE_BOX_TIMER',
+                                            DEFAULT_WAIT_PERSISTENCE_BOX_TIMER)
+
+        if 'box' not in self.__dict__:
+            self.box = None
+        self.list_stored_boxes()
+
+    def get_data(self):
+        """Return the persistence box data."""
+        # Wait retrieve or create box in storehouse
+        while not self.box:
+            time.sleep(self.wait_persistence_box)
+        return self.box.data
+
+    def create_box(self):
+        """Create a persistence box to store administrative changes."""
+        content = {'namespace': self.namespace,
+                   'callback': self._create_box_callback,
+                   'data': {}}
+        event = KytosEvent(name='kytos.storehouse.create', content=content)
+        self.controller.buffers.app.put(event)
+
+    def _create_box_callback(self, _event, data, error):
+        """Execute the callback to handle create_box."""
+        if error:
+            log.error(f'Can\'t create persistence'
+                      f'box with namespace {self.namespace}')
+
+        self.box = data
+
+    def list_stored_boxes(self):
+        """List all persistence box stored in storehouse."""
+        name = 'kytos.storehouse.list'
+        content = {'namespace': self.namespace,
+                   'callback': self._get_or_create_a_box_from_list_of_boxes}
+
+        event = KytosEvent(name=name, content=content)
+        self.controller.buffers.app.put(event)
+
+    def _get_or_create_a_box_from_list_of_boxes(self, _event, data, _error):
+        """Create a persistence box or retrieve the stored box."""
+        if data:
+            self.get_stored_box(data[0])
+        else:
+            self.create_box()
+
+    def get_stored_box(self, box_id):
+        """Get persistence box from storehouse."""
+        content = {'namespace': self.namespace,
+                   'callback': self._get_box_callback,
+                   'box_id': box_id,
+                   'data': {}}
+        name = 'kytos.storehouse.retrieve'
+        event = KytosEvent(name=name, content=content)
+        self.controller.buffers.app.put(event)
+
+    def _get_box_callback(self, _event, data, error):
+        """Handle get_box method saving the box or logging with the error."""
+        if error:
+            log.error('Persistence box not found.')
+
+        self.box = data
+
+    def save_flow(self, flows):
+        """Save flows in storehouse."""
+        self.box.data[flows['id']] = flows
+        content = {'namespace': self.namespace,
+                   'box_id': self.box.box_id,
+                   'data': self.box.data,
+                   'callback': self._save_flow_callback}
+
+        event = KytosEvent(name='kytos.storehouse.update', content=content)
+        self.controller.buffers.app.put(event)
+
+    def _save_flow_callback(self, _event, data, error):
+        """Display stored flow."""
+        if error:
+            log.error(f'Can\'t update persistence box {data.box_id}.')
+
+        log.info(f'Flow saved in {self.namespace}.{data.box_id}')

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -200,7 +200,7 @@ class TestMain(TestCase):
         flow = {"command": "add", "flow": MagicMock()}
 
         flows = {"flow_list": [flow]}
-        mock_event.content = {"switch": dpid}
+        mock_event.content = {"switch": switch}
         self.napp.controller.switches = {dpid: switch}
         self.napp.stored_flows = {dpid: flows}
         self.napp.resend_stored_flows(mock_event)

--- a/tests/unit/test_storehouse.py
+++ b/tests/unit/test_storehouse.py
@@ -1,0 +1,86 @@
+"""Module to test the storehouse client."""
+from unittest import TestCase
+from unittest.mock import MagicMock, PropertyMock, patch
+
+from kytos.lib.helpers import get_controller_mock
+
+
+# pylint: disable=too-many-public-methods
+class TestStoreHouse(TestCase):
+    """Test the Main class."""
+
+    def setUp(self):
+        """Execute steps before each tests.
+
+        Set the server_name_url_url from kytos/flow_manager
+        """
+        self.server_name_url = 'http://localhost:8181/api/kytos/flow_manager'
+
+        patch('kytos.core.helpers.run_on_thread', lambda x: x).start()
+        # pylint: disable=import-outside-toplevel
+        from napps.kytos.flow_manager.storehouse import StoreHouse
+        self.addCleanup(patch.stopall)
+
+        self.napp = StoreHouse(get_controller_mock())
+
+    @patch('napps.kytos.flow_manager.storehouse.StoreHouse.get_stored_box')
+    def test_get_data(self, mock_get_stored_box):
+        """Test get_data."""
+        mock_box = MagicMock()
+        box_data = MagicMock()
+        mock_get_stored_box.return_value = True
+        type(box_data).data = PropertyMock(side_effect=[{}, "box"])
+        type(mock_box).data = PropertyMock(return_value=box_data)
+        self.napp.box = mock_box
+        response = self.napp.get_data()
+        self.assertEqual(response.data, {})
+
+        response = self.napp.get_data()
+        self.assertEqual(response.data, "box")
+
+    @patch('napps.kytos.flow_manager.storehouse.KytosEvent')
+    @patch('kytos.core.buffers.KytosEventBuffer.put')
+    def test_create_box(self, *args):
+        """Test create_box."""
+        (mock_buffers_put, mock_event) = args
+        self.napp.create_box()
+        mock_event.assert_called()
+        mock_buffers_put.assert_called()
+
+    # pylint: disable = protected-access
+    @patch('napps.kytos.flow_manager.storehouse.StoreHouse.get_stored_box')
+    @patch('napps.kytos.flow_manager.storehouse.StoreHouse.create_box')
+    def test_get_or_create_a_box_from_list_of_boxes(self, *args):
+        """Test create_box."""
+        (mock_create_box, mock_get_stored_box) = args
+        mock_event = MagicMock()
+        mock_data = MagicMock()
+        mock_error = MagicMock()
+        self.napp._get_or_create_a_box_from_list_of_boxes(mock_event,
+                                                          mock_data,
+                                                          mock_error)
+        mock_get_stored_box.assert_called()
+        self.napp._get_or_create_a_box_from_list_of_boxes(mock_event,
+                                                          None,
+                                                          mock_error)
+        mock_create_box.assert_called()
+
+    @patch('napps.kytos.flow_manager.storehouse.KytosEvent')
+    @patch('kytos.core.buffers.KytosEventBuffer.put')
+    def test_get_stored_box(self, *args):
+        """Test get_stored_box."""
+        (mock_buffers_put, mock_event) = args
+        mock_box = MagicMock()
+        self.napp.get_stored_box(mock_box)
+        mock_event.assert_called()
+        mock_buffers_put.assert_called()
+
+    @patch('napps.kytos.flow_manager.storehouse.KytosEvent')
+    @patch('kytos.core.buffers.KytosEventBuffer.put')
+    def test_save_flow(self, *args):
+        """Test save_status."""
+        (mock_buffers_put, mock_event) = args
+        mock_status = MagicMock()
+        self.napp.save_flow(mock_status)
+        mock_event.assert_called()
+        mock_buffers_put.assert_called()


### PR DESCRIPTION
### :octocat: Issue
This PR fixes #89 

### :bookmark_tabs: Description of the Change

This change adds a flow persistence mechanism to the` flow_manager` NApp. All flows installed using` flow_manager` are now persisted in the `storehouse`, this feature also adds a method to resend flows stored in the storehouse when the `kytos/of_core.handshake.completed` event is heard.
All flows are stored in the `storehouse` until the administrator deletes the flow persistence box (`kytos.flow.persistence`), including the removed flows (allowing for an audit and consistency check).

### :computer: Verification Process

Besides running unit tests, I checked manually the installation process for new flows.

### :page_facing_up: Release Notes

- Add persistence mechanism to store in `storehouse` flows installed by `flow_manager`.
- Add mechanism to resend stored flows in Kytos bootstrap.
