### PR TITLE
Remove flow from switch even when it's disabled

### DIFF
--- a/main.py
+++ b/main.py
@@ -92,7 +92,10 @@ class Main(KytosNApp):
             if not switch:
                 return jsonify({"response": 'dpid not found.'}), 404
             elif switch.is_enabled() is False:
-                return jsonify({"response": 'switch is disabled.'}), 404
+                if command == "delete":
+                    self._install_flows(command, flows_dict, [switch])
+                else:
+                    return jsonify({"response": 'switch is disabled.'}), 404
             else:
                 self._install_flows(command, flows_dict, [switch])
         else:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,7 +6,7 @@
 #
 -e git+git://github.com/kytos/kytos.git#egg=kytos
 -e git+git://github.com/kytos/python-openflow.git#egg=python-openflow
--e git+git://github.com/kytos/of_core.git#egg=of_core
+-e git+git://github.com/kytos/of_core.git#egg=kytos-of-core
 -e .
 astroid==2.2.5            # via pylint
 click==7.0                # via flask, pip-tools

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -99,10 +99,13 @@ class TestMain(TestCase):
 
             self.assertEqual(response_1.status_code, 404)
             self.assertEqual(response_2.status_code, 200)
-            self.assertEqual(response_3.status_code, 404)
+            if method == 'flows':
+                self.assertEqual(response_3.status_code, 404)
+            else:
+                self.assertEqual(response_3.status_code, 200)
             self.assertEqual(response_4.status_code, 404)
 
-        self.assertEqual(mock_install_flows.call_count, 2)
+        self.assertEqual(mock_install_flows.call_count, 3)
 
     def test_get_all_switches_enabled(self):
         """Test _get_all_switches_enabled method."""


### PR DESCRIPTION

### :octocat: Are you working on some issue? Identify the issue!
Fix https://github.com/kytos/flow_manager/issues/99

### :bookmark_tabs: Description of the Change

This commit allows remove flows in disabled switch because 'of_lldp'
and 'of_l2ls' needs to remove their installed flows once a switch is disabled.


### :page_facing_up: Release Notes

Update flow installation to allow removal of flows from disabled switches.
