### PR TITLE
Add attempt limits to try to retrieve box from storehouse

### DIFF
--- a/main.py
+++ b/main.py
@@ -147,8 +147,7 @@ class Main(KytosNApp):
             if 'id' in data:
                 del data['id']
             self.stored_flows = data
-
-        except KeyError as error:
+        except (KeyError, FileNotFoundError) as error:
             log.debug(f'There are no flows to load: {error}')
         else:
             log.info('Flows loaded.')

--- a/settings.py
+++ b/settings.py
@@ -3,5 +3,5 @@
 STATS_INTERVAL = 30
 FLOWS_DICT_MAX_SIZE = 10000
 # Time (in seconds) to wait retrieve box from storehouse
-WAIT_PERSISTENCE_BOX_TIMER = 0.1
+BOX_RESTORE_TIMER = 0.1
 CONSISTENCY_INTERVAL = 60


### PR DESCRIPTION
### :octocat: Are you working on some issue? Identify the issue!

#110 

### :bookmark_tabs: Description of the Change

Added attempt limits to try to recover box from storehouse, avoiding
a possible thread lock condition.


### :computer: Verification Process

- All unit tests are still passing.

### :page_facing_up: Release Notes

- Add attempt limits to try to retrieve box from storehouse
