### PR TITLE
Add support to list of exceptions in consistency mechanism

### DIFF
--- a/main.py
+++ b/main.py
@@ -30,16 +30,15 @@ def cast_fields(flow_dict):
 
 def _validate_range(values):
     """Check that the range of flows ignored by the consistency is valid."""
-    instance = int
     if len(values) != 2:
         msg = f'The tuple must have 2 items, not {len(values)}'
         raise ValueError(msg)
     first, second = values
     if second < first:
-        msg = (f'The first value is bigger than the second: {values}')
+        msg = f'The first value is bigger than the second: {values}'
         raise ValueError(msg)
-    if not isinstance(first, instance) or not isinstance(second, instance):
-        msg = 'The elements of the range must be of the class {instance}'
+    if not isinstance(first, int) or not isinstance(second, int):
+        msg = f'Expected a tuple of integers, received {values}'
         raise TypeError(msg)
 
 

--- a/main.py
+++ b/main.py
@@ -36,7 +36,7 @@ def _is_valid_range(values, instance):
         raise ValueError(msg)
     first, second = values
     if second < first:
-        msg = f'The range is not well formatted: {values}'
+        msg = (f'The first value is bigger than the second: {values}')
         raise ValueError(msg)
     if not isinstance(first, instance) or not isinstance(second, instance):
         msg = 'The elements of the range must be of the class {instance}'
@@ -48,7 +48,8 @@ def validate_input(exceptions):
 
     Returns True if the consistency exception input are well formatted.
     """
-    msg = 'Consistency exception is not well formatted: %s'
+    msg = ('The list of consistency exception is not well formatted'
+           ', it will be ignored: %s')
     for exception in exceptions:
         if isinstance(exception, tuple):
             try:
@@ -76,6 +77,8 @@ class Main(KytosNApp):
         log.debug("flow-manager starting")
         self._flow_mods_sent = OrderedDict()
         self._flow_mods_sent_max_size = FLOWS_DICT_MAX_SIZE
+        self.cookie_exception_range = []
+        self.tab_id_exception_range = []
         if validate_input(CONSISTENCY_COOKIE_EXCEPTION_RANGE):
             self.cookie_exception_range = CONSISTENCY_COOKIE_EXCEPTION_RANGE
         if validate_input(CONSISTENCY_TABLE_ID_EXCEPTION_RANGE):
@@ -130,7 +133,7 @@ class Main(KytosNApp):
             log.info(f'Flows resent to Switch {dpid}')
 
     @staticmethod
-    def in_range(field, exceptions):
+    def is_exception(field, exceptions):
         """Check if the field are in the list of exceptions.
 
         Returns True if the field is in the list of exceptions.
@@ -152,11 +155,11 @@ class Main(KytosNApp):
         Returns True if the flow is in the exception list.
         """
         # Check by cookie
-        if self.in_range(flow.cookie, self.cookie_exception_range):
+        if self.is_exception(flow.cookie, self.cookie_exception_range):
             return True
 
         # Check by `table_id`
-        if self.in_range(flow.table_id, self.tab_id_exception_range):
+        if self.is_exception(flow.table_id, self.tab_id_exception_range):
             return True
         return False
 

--- a/settings.py
+++ b/settings.py
@@ -7,6 +7,7 @@ BOX_RESTORE_TIMER = 0.1
 CONSISTENCY_INTERVAL = 60
 
 # List of exceptions in the consistency mechanism
-# [begin, end]
+# To filter by a cookie or `table_id` use [value]
+# To filter by a cookie or `table_id` range [(value1, value2)]
 CONSISTENCY_COOKIE_EXCEPTION_RANGE = []
 CONSISTENCY_TABLE_ID_EXCEPTION_RANGE = []

--- a/settings.py
+++ b/settings.py
@@ -6,8 +6,8 @@ FLOWS_DICT_MAX_SIZE = 10000
 BOX_RESTORE_TIMER = 0.1
 CONSISTENCY_INTERVAL = 60
 
-# List of exceptions in the consistency mechanism
+# List of flows ignored by the consistency check
 # To filter by a cookie or `table_id` use [value]
 # To filter by a cookie or `table_id` range [(value1, value2)]
-CONSISTENCY_COOKIE_EXCEPTION_RANGE = []
-CONSISTENCY_TABLE_ID_EXCEPTION_RANGE = []
+CONSISTENCY_COOKIE_IGNORED_RANGE = []
+CONSISTENCY_TABLE_ID_IGNORED_RANGE = []

--- a/settings.py
+++ b/settings.py
@@ -5,3 +5,8 @@ FLOWS_DICT_MAX_SIZE = 10000
 # Time (in seconds) to wait retrieve box from storehouse
 BOX_RESTORE_TIMER = 0.1
 CONSISTENCY_INTERVAL = 60
+
+# List of exceptions in the consistency mechanism
+# [begin, end]
+CONSISTENCY_COOKIE_EXCEPTION_RANGE = []
+CONSISTENCY_TABLE_ID_EXCEPTION_RANGE = []

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -582,9 +582,9 @@ class TestMain(TestCase):
         (mock_flow_factory, mock_install_flows) = args
         dpid = "00:00:00:00:00:00:00:01"
         switch = get_switch_mock(dpid, 0x04)
-        cookie_exception_interval = [(0x2b00000000000011,
-                                      0x2b000000000000ff), 0x2b00000000000100]
-        self.napp.cookie_exception_range = cookie_exception_interval
+        cookie_ignored_interval = [(0x2b00000000000011,
+                                    0x2b000000000000ff), 0x2b00000000000100]
+        self.napp.cookie_ignored_range = cookie_ignored_interval
         flow = MagicMock()
         expected = [
                     {'cookie': 0x2b00000000000010, 'called': 1},
@@ -606,13 +606,13 @@ class TestMain(TestCase):
 
     @patch('napps.kytos.flow_manager.main.Main._install_flows')
     @patch('napps.kytos.flow_manager.main.FlowFactory.get_class')
-    def test_consistency_table_id_exception_range(self, *args):
-        """Test the consistency `table_id` exception range."""
+    def test_consistency_table_id_ignored_range(self, *args):
+        """Test the consistency `table_id` ignored range."""
         (mock_flow_factory, mock_install_flows) = args
         dpid = "00:00:00:00:00:00:00:01"
         switch = get_switch_mock(dpid, 0x04)
-        table_id_exception_interval = [(1, 2), 3]
-        self.napp.tab_id_exception_range = table_id_exception_interval
+        table_id_ignored_interval = [(1, 2), 3]
+        self.napp.tab_id_ignored_range = table_id_ignored_interval
         flow = MagicMock()
         expected = [
                     {'table_id': 0, 'called': 1},

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -323,6 +323,7 @@ class TestMain(TestCase):
                       "flow": {'flow_1': 'data'}
                       }]
         serializer = MagicMock()
+        serializer.flow.cookie.return_value = 0
 
         mock_flow_factory.return_value = serializer
         self.napp.stored_flows = {dpid: {"flow_list": flow_list}}
@@ -365,18 +366,20 @@ class TestMain(TestCase):
         This test checks the case when a flow is missing in storehouse.
         """
         (mock_flow_factory, mock_install_flows) = args
+        cookie_exception_interval = [0x2b00000000000011, 0x2b000000000000ff]
+        self.napp.cookie_exception_range = cookie_exception_interval
         dpid = "00:00:00:00:00:00:00:01"
         switch = get_switch_mock(dpid, 0x04)
-
         flow_1 = MagicMock()
-        flow_1.as_dict.return_value = {'flow_1': 'data'}
+        flow_1.cookie = 0x2b00000000000010
+        flow_1.as_dict.return_value = {'flow_1': 'data', 'cookie': 1}
 
         switch.flows = [flow_1]
 
         flow_list = [{"command": "add",
-                      "flow": {'flow_2': 'data'}
+                      "flow": {'flow_2': 'data', 'cookie': 1}
                       }]
-        serializer = MagicMock()
+        serializer = flow_1
 
         mock_flow_factory.return_value = serializer
         self.napp.stored_flows = {dpid: {"flow_list": flow_list}}
@@ -571,3 +574,41 @@ class TestMain(TestCase):
         self.napp._store_changed_flows(command, flow_to_install, switch)
         mock_save_flow.assert_called()
         self.assertEqual(len(self.napp.stored_flows[dpid]['flow_list']), 1)
+
+    @patch('napps.kytos.flow_manager.main.Main._install_flows')
+    @patch('napps.kytos.flow_manager.main.FlowFactory.get_class')
+    def test_consistency_cookie_exception_range(self, *args):
+        """Test the consistency `cookie` exception range."""
+        (mock_flow_factory, mock_install_flows) = args
+        dpid = "00:00:00:00:00:00:00:01"
+        switch = get_switch_mock(dpid, 0x04)
+        cookie_exception_interval = [0x2b00000000000011, 0x2b000000000000ff]
+        self.napp.cookie_exception_range = cookie_exception_interval
+        flow = MagicMock()
+        # ignored flow
+        flow.cookie = 0x2b00000000000013
+        flow.as_dict.return_value = {'flow_1': 'data', 'cookie': 1}
+        switch.flows = [flow]
+        mock_flow_factory.return_value = flow
+        self.napp.stored_flows = {dpid: {"flow_list": flow}}
+        self.napp.check_storehouse_consistency(switch)
+        self.assertEqual(mock_install_flows.call_count, 0)
+
+    @patch('napps.kytos.flow_manager.main.Main._install_flows')
+    @patch('napps.kytos.flow_manager.main.FlowFactory.get_class')
+    def test_consistency_table_id_exception_range(self, *args):
+        """Test the consistency `table_id` exception range."""
+        (mock_flow_factory, mock_install_flows) = args
+        dpid = "00:00:00:00:00:00:00:01"
+        switch = get_switch_mock(dpid, 0x04)
+        table_id_exception_interval = [1, 2]
+        self.napp.table_id_exception_range = table_id_exception_interval
+        flow = MagicMock()
+        # ignored flow
+        flow.table_id = 1
+        flow.as_dict.return_value = {'flow_1': 'data', 'cookie': 1}
+        switch.flows = [flow]
+        mock_flow_factory.return_value = flow
+        self.napp.stored_flows = {dpid: {"flow_list": flow}}
+        self.napp.check_storehouse_consistency(switch)
+        self.assertEqual(mock_install_flows.call_count, 0)


### PR DESCRIPTION
### :octocat: Are you working on some issue? Identify the issue!
Fix https://github.com/kytos/kytos/issues/1221
Related https://github.com/kytos/kytos/issues/1120

### :bookmark_tabs: Description of the Change

Add support for consistency checking to ignore flows by `cookie` range and `table_id` range.
This feature is interesting to avoid accidental removal of `administrative flows` installed by external tools.

## How to use:

The user can define the interval that is ignored in the `setting.py` file.


Format:
``` python
[(begin, end)]  # Flows in this interval are not verified by the consistency mechanism
[cookie] # Flow that have this cookie are not veridied by the consistency mechanism
[table_id] # Flow that have this `table_id` are not verified by the consistency mechanism

```
Using `cookie` range:

``` python
CONSISTENCY_COOKIE_IGNORED_RANGE = [(0x2b00000000000011, 0x2b000000000000ff)]
```
The flows that if  the `flow.cookie` field are in this range are ignored by the consistency check.

Filtering for a unique _cookie_:

``` python
CONSISTENCY_COOKIE_IGNORED_RANGE = [0x2b00000000000011]
```

Filtering by range and single value:

``` python
CONSISTENCY_COOKIE_IGNORED_RANGE = [0x2b00000000000011, (0x2b00000000000014, 0x2b00000000000017)]
```

Using `table_id` range:

``` python
CONSISTENCY_TABLE_ID_IGNORED_RANGE = [(1, 2)]
```

The flows that if  the `flow.table_id` field are in this range are ignored by the consistency check.

## Need to know

By default, all flows are checked by the consistency mechanism. 
``` python
CONSISTENCY_COOKIE_IGNORED_RANGE = []
CONSISTENCY_TABLE_ID_IGNORED_RANGE = []
```
For the exception interval mechanism to work it is necessary to define an  **initial** and **final** value in the tuple. If the final value is not defined, only the first value will be excluded.

_This PR can be changed in the review process._
### :computer: Verification Process

- All unit tests are still passing.

### :page_facing_up: Release Notes

- Add support for the list of exceptions in the consistency mechanism