### PR TITLE
Add support for `DELETE_STRICT` in the consistency check

### DIFF
--- a/main.py
+++ b/main.py
@@ -109,6 +109,7 @@ class Main(KytosNApp):
             elif command == 'delete':
                 log.info('A consistency problem was detected in '
                          f'switch {dpid}.')
+                command = 'strict_delete'
                 self._install_flows(command, flow, [switch])
                 log.info(f'Flow forwarded to switch {dpid} to be deleted.')
 
@@ -121,7 +122,7 @@ class Main(KytosNApp):
                 log.info('A consistency problem was detected in '
                          f'switch {dpid}.')
                 flow = {'flows': [installed_flow.as_dict()]}
-                command = 'delete'
+                command = 'strict_delete'
                 self._install_flows(command, flow, [switch])
                 log.info(f'Flow forwarded to switch {dpid} to be deleted.')
             else:
@@ -135,7 +136,7 @@ class Main(KytosNApp):
                     log.info('A consistency problem was detected in '
                              f'switch {dpid}.')
                     flow = {'flows': [installed_flow.as_dict()]}
-                    command = 'delete'
+                    command = 'strict_delete'
                     self._install_flows(command, flow, [switch])
                     log.info(f'Flow forwarded to switch {dpid} to be deleted.')
 
@@ -289,6 +290,8 @@ class Main(KytosNApp):
                 flow = serializer.from_dict(flow_dict, switch)
                 if command == "delete":
                     flow_mod = flow.as_of_delete_flow_mod()
+                elif command == "strict_delete":
+                    flow_mod = flow.as_of_strict_delete_flow_mod()
                 elif command == "add":
                     flow_mod = flow.as_of_add_flow_mod()
                 else:
@@ -318,7 +321,7 @@ class Main(KytosNApp):
         """Send an Event to other apps informing about a FlowMod."""
         if command == 'add':
             name = 'kytos/flow_manager.flow.added'
-        elif command == 'delete':
+        elif command in ('delete', 'strict_delete'):
             name = 'kytos/flow_manager.flow.removed'
         elif command == 'error':
             name = 'kytos/flow_manager.flow.error'

--- a/main.py
+++ b/main.py
@@ -109,7 +109,7 @@ class Main(KytosNApp):
             elif command == 'delete':
                 log.info('A consistency problem was detected in '
                          f'switch {dpid}.')
-                command = 'strict_delete'
+                command = 'delete_strict'
                 self._install_flows(command, flow, [switch])
                 log.info(f'Flow forwarded to switch {dpid} to be deleted.')
 
@@ -122,7 +122,7 @@ class Main(KytosNApp):
                 log.info('A consistency problem was detected in '
                          f'switch {dpid}.')
                 flow = {'flows': [installed_flow.as_dict()]}
-                command = 'strict_delete'
+                command = 'delete_strict'
                 self._install_flows(command, flow, [switch])
                 log.info(f'Flow forwarded to switch {dpid} to be deleted.')
             else:
@@ -136,7 +136,7 @@ class Main(KytosNApp):
                     log.info('A consistency problem was detected in '
                              f'switch {dpid}.')
                     flow = {'flows': [installed_flow.as_dict()]}
-                    command = 'strict_delete'
+                    command = 'delete_strict'
                     self._install_flows(command, flow, [switch])
                     log.info(f'Flow forwarded to switch {dpid} to be deleted.')
 
@@ -290,7 +290,7 @@ class Main(KytosNApp):
                 flow = serializer.from_dict(flow_dict, switch)
                 if command == "delete":
                     flow_mod = flow.as_of_delete_flow_mod()
-                elif command == "strict_delete":
+                elif command == "delete_strict":
                     flow_mod = flow.as_of_strict_delete_flow_mod()
                 elif command == "add":
                     flow_mod = flow.as_of_add_flow_mod()
@@ -321,7 +321,7 @@ class Main(KytosNApp):
         """Send an Event to other apps informing about a FlowMod."""
         if command == 'add':
             name = 'kytos/flow_manager.flow.added'
-        elif command in ('delete', 'strict_delete'):
+        elif command in ('delete', 'delete_strict'):
             name = 'kytos/flow_manager.flow.removed'
         elif command == 'error':
             name = 'kytos/flow_manager.flow.error'

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -146,7 +146,7 @@ class TestMain(TestCase):
     @patch('napps.kytos.flow_manager.main.Main._add_flow_mod_sent')
     @patch('napps.kytos.flow_manager.main.Main._send_flow_mod')
     @patch('napps.kytos.flow_manager.main.FlowFactory.get_class')
-    def test_install_flows_with_strict_delete(self, *args):
+    def test_install_flows_with_delete_strict(self, *args):
         """Test _install_flows method with strict delete command."""
         (mock_flow_factory, mock_send_flow_mod, mock_add_flow_mod_sent,
          mock_send_napp_event, _) = args
@@ -160,13 +160,13 @@ class TestMain(TestCase):
 
         flows_dict = {'flows': [MagicMock()]}
         switches = [self.switch_01]
-        self.napp._install_flows('strict_delete', flows_dict, switches)
+        self.napp._install_flows('delete_strict', flows_dict, switches)
 
         mock_send_flow_mod.assert_called_with(flow.switch, flow_mod)
         mock_add_flow_mod_sent.assert_called_with(flow_mod.header.xid,
-                                                  flow, 'strict_delete')
+                                                  flow, 'delete_strict')
         mock_send_napp_event.assert_called_with(self.switch_01, flow,
-                                                'strict_delete')
+                                                'delete_strict')
 
     def test_add_flow_mod_sent(self):
         """Test _add_flow_mod_sent method."""
@@ -193,7 +193,7 @@ class TestMain(TestCase):
         switch = get_switch_mock("00:00:00:00:00:00:00:01", 0x04)
         flow = MagicMock()
 
-        for command in ['add', 'delete', 'strict_delete', 'error']:
+        for command in ['add', 'delete', 'delete_strict', 'error']:
             self.napp._send_napp_event(switch, flow, command)
 
         self.assertEqual(mock_buffers_put.call_count, 4)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -141,6 +141,33 @@ class TestMain(TestCase):
                                                   flow, 'add')
         mock_send_napp_event.assert_called_with(self.switch_01, flow, 'add')
 
+    @patch('napps.kytos.flow_manager.main.Main._store_changed_flows')
+    @patch('napps.kytos.flow_manager.main.Main._send_napp_event')
+    @patch('napps.kytos.flow_manager.main.Main._add_flow_mod_sent')
+    @patch('napps.kytos.flow_manager.main.Main._send_flow_mod')
+    @patch('napps.kytos.flow_manager.main.FlowFactory.get_class')
+    def test_install_flows_with_strict_delete(self, *args):
+        """Test _install_flows method with strict delete command."""
+        (mock_flow_factory, mock_send_flow_mod, mock_add_flow_mod_sent,
+         mock_send_napp_event, _) = args
+        serializer = MagicMock()
+        flow = MagicMock()
+        flow_mod = MagicMock()
+
+        flow.as_of_strict_delete_flow_mod.return_value = flow_mod
+        serializer.from_dict.return_value = flow
+        mock_flow_factory.return_value = serializer
+
+        flows_dict = {'flows': [MagicMock()]}
+        switches = [self.switch_01]
+        self.napp._install_flows('strict_delete', flows_dict, switches)
+
+        mock_send_flow_mod.assert_called_with(flow.switch, flow_mod)
+        mock_add_flow_mod_sent.assert_called_with(flow_mod.header.xid,
+                                                  flow, 'strict_delete')
+        mock_send_napp_event.assert_called_with(self.switch_01, flow,
+                                                'strict_delete')
+
     def test_add_flow_mod_sent(self):
         """Test _add_flow_mod_sent method."""
         xid = 0
@@ -166,10 +193,10 @@ class TestMain(TestCase):
         switch = get_switch_mock("00:00:00:00:00:00:00:01", 0x04)
         flow = MagicMock()
 
-        for command in ['add', 'delete', 'error']:
+        for command in ['add', 'delete', 'strict_delete', 'error']:
             self.napp._send_napp_event(switch, flow, command)
 
-        self.assertEqual(mock_buffers_put.call_count, 3)
+        self.assertEqual(mock_buffers_put.call_count, 4)
 
     @patch('napps.kytos.flow_manager.main.Main._send_napp_event')
     def test_handle_errors(self, mock_send_napp_event):


### PR DESCRIPTION
# Pull Request Template

### :octocat: Are you working on some issue? Identify the issue!

Fix #118 
Related https://github.com/kytos/of_core/pull/118

### :bookmark_tabs: Description of the Change

Change the consistency check to use `DELETE_STRICT` instead of `DELETE` to remove 'alien' Flows from the switches.
This change avoids a wrong action that removes all flows from a switch.

This pull request needs the changes made in the PR https://github.com/kytos/of_core/pull/118

### :computer: Verification Process

- Unit tests are still passing.

### :page_facing_up: Release Notes

- Change the consistency check to use `DELETE_STRICT` instead of `DELETE` to remove 'alien' Flows from the switches
