### PR TITLE
Add listening to of_core flow_stats.received to run consistency check

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,9 +15,9 @@ from napps.kytos.flow_manager.storehouse import StoreHouse
 from napps.kytos.of_core.flow import FlowFactory
 
 from .exceptions import InvalidCommandError
-from .settings import ENABLE_CONSISTENCY_CHECK
 from .settings import (CONSISTENCY_COOKIE_IGNORED_RANGE,
-                       CONSISTENCY_TABLE_ID_IGNORED_RANGE, FLOWS_DICT_MAX_SIZE)
+                       CONSISTENCY_TABLE_ID_IGNORED_RANGE,
+                       ENABLE_CONSISTENCY_CHECK, FLOWS_DICT_MAX_SIZE)
 
 
 def cast_fields(flow_dict):
@@ -209,7 +209,7 @@ class Main(KytosNApp):
 
         for installed_flow in switch.flows:
 
-            # Check if the flow are in the ignored flow list
+            # Check if the flow is in the ignored flow list
             if self.consistency_ignored_check(installed_flow):
                 continue
 

--- a/main.py
+++ b/main.py
@@ -167,6 +167,17 @@ class Main(KytosNApp):
             return True
         return False
 
+    @listen_to('kytos/of_core.flow_stats.received')
+    def on_flow_stats_check_consistency(self, event):
+        """Check the consistency of a switch upon receiving flow stats."""
+        if CONSISTENCY_INTERVAL != 0:
+            return
+        switch = event.content['switch']
+        if switch.is_enabled():
+            self.check_storehouse_consistency(switch)
+            if switch.dpid in self.stored_flows:
+                self.check_switch_consistency(switch)
+
     def consistency_check(self):
         """Check the consistency of flows in each switch."""
         switches = self.controller.switches.values()

--- a/main.py
+++ b/main.py
@@ -113,7 +113,7 @@ class Main(KytosNApp):
     def resend_stored_flows(self, event):
         """Resend stored Flows."""
         # if consistency check is enabled, it should take care of this
-        if CONSISTENCY_INTERVAL >= 0:
+        if ENABLE_CONSISTENCY_CHECK is True:
             return
         switch = event.content['switch']
         dpid = str(switch.dpid)

--- a/main.py
+++ b/main.py
@@ -113,7 +113,7 @@ class Main(KytosNApp):
     def resend_stored_flows(self, event):
         """Resend stored Flows."""
         # if consistency check is enabled, it should take care of this
-        if ENABLE_CONSISTENCY_CHECK is True:
+        if ENABLE_CONSISTENCY_CHECK:
             return
         switch = event.content['switch']
         dpid = str(switch.dpid)
@@ -166,7 +166,7 @@ class Main(KytosNApp):
     @listen_to('kytos/of_core.flow_stats.received')
     def on_flow_stats_check_consistency(self, event):
         """Check the consistency of a switch upon receiving flow stats."""
-        if ENABLE_CONSISTENCY_CHECK is False:
+        if not ENABLE_CONSISTENCY_CHECK:
             return
         switch = event.content['switch']
         if switch.is_enabled():

--- a/settings.py
+++ b/settings.py
@@ -4,12 +4,7 @@ STATS_INTERVAL = 30
 FLOWS_DICT_MAX_SIZE = 10000
 # Time (in seconds) to wait retrieve box from storehouse
 BOX_RESTORE_TIMER = 0.1
-# CONSISTENCY_INTERVAL defines the strategy and interval
-# to run the consistency check
-#  CONSISTENCY_INTERVAL = 0 --> run based on the flow_stats.received event
-#  CONSISTENCY_INTERVAL < 0 --> disables consistency check
-#  CONSISTENCY_INTERVAL > 0 --> run periodically based on the interval
-CONSISTENCY_INTERVAL = 0
+ENABLE_CONSISTENCY_CHECK = True
 
 # List of flows ignored by the consistency check
 # To filter by a cookie or `table_id` use [value]

--- a/settings.py
+++ b/settings.py
@@ -4,7 +4,12 @@ STATS_INTERVAL = 30
 FLOWS_DICT_MAX_SIZE = 10000
 # Time (in seconds) to wait retrieve box from storehouse
 BOX_RESTORE_TIMER = 0.1
-CONSISTENCY_INTERVAL = 60
+# CONSISTENCY_INTERVAL defines the strategy and interval
+# to run the consistency check
+#  CONSISTENCY_INTERVAL = 0 --> run based on the flow_stats.received event
+#  CONSISTENCY_INTERVAL < 0 --> disables consistency check
+#  CONSISTENCY_INTERVAL > 0 --> run periodically based on the interval
+CONSISTENCY_INTERVAL = 0
 
 # List of flows ignored by the consistency check
 # To filter by a cookie or `table_id` use [value]

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -276,7 +276,7 @@ class TestMain(TestCase):
         self.napp._load_flows()
         mock_storehouse.assert_called()
 
-    @patch("napps.kytos.flow_manager.main.CONSISTENCY_INTERVAL", -1)
+    @patch("napps.kytos.flow_manager.main.ENABLE_CONSISTENCY_CHECK", False)
     @patch("napps.kytos.flow_manager.main.Main._install_flows")
     def test_resend_stored_flows(self, mock_install_flows):
         """Test resend stored flows."""


### PR DESCRIPTION
Currently, the consistency check routine is run every settings.CONSISTENCY_INTERVAL seconds. The consistency check depends on the switch's flow list to compare with the stored flows. However, since the switch's flow list is updated by of_core flow_stats routine, those intervals may not match and this can leads to an inconsistent switch flow table view, such as the issue #124.

This PR adds the capability of running the consistency check based on the of_core flow_stats received event, which will improve the reliability of the consistency check routine, once it will with the most updated switch flow table.

The way it was developed enables the consistency check to run in three different ways:
- Disabled: when CONSISTENCY_INTERVAL is lower than zero (e.g., -1), it will not be run
- Event based: when CONSISTENCY_INTERVAL is equal zero, it will be run upon receiving the kytos/of_core.flow_stats.received event
- Periodically: when CONSISTENCY_INTERVAL is greater zero, it will run as currently deployed - with its own interval

The PR also changes the default value of CONSISTENCY_INTERVAL to zero, since it seems to be the more secure and efficient approach.

Fixes #124 

UPDATE:
- According to our discussion, this PR now changes the behavior of the consistency check to run upon receiving the flow_stats.received event from of_core. The flow_manager settings allow to enable or disable consistency check (it is enabled by default)