### PR TITLE
Avoid recreating flows for a connected switch when consistency check is enabled

### DIFF
--- a/main.py
+++ b/main.py
@@ -57,6 +57,9 @@ class Main(KytosNApp):
     @listen_to('kytos/of_core.handshake.completed')
     def resend_stored_flows(self, event):
         """Resend stored Flows."""
+        # if consistency check is enabled, it should take care of this
+        if CONSISTENCY_INTERVAL >= 0:
+            return
         switch = event.content['switch']
         dpid = str(switch.dpid)
         # This can be a problem because this code is running a thread

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -232,6 +232,7 @@ class TestMain(TestCase):
         self.napp._load_flows()
         mock_storehouse.assert_called()
 
+    @patch("napps.kytos.flow_manager.main.CONSISTENCY_INTERVAL", -1)
     @patch("napps.kytos.flow_manager.main.Main._install_flows")
     def test_resend_stored_flows(self, mock_install_flows):
         """Test resend stored flows."""


### PR DESCRIPTION
Currently, when a switch connect (or reconnects) to Kytos, flow_manager send a FLOW_MOD to reinstall all the stored flows, no matter how is the switch flow table.

If the switch flow table is empty, forcing the flows to be reinstalled is okay. However, if the switch still has the flows and reconnects, reinstalling them will impact the traffic being forwarded, will clear the statistics, and is waste of resources. Furthermore, with the recent consistency check routine, this should be handed over.

This PR changes the behavior of flow_manager to use the consistency check routine, when enabled, to recreate the flows when the switch reconnects to Kytos.

Fixes #115 