### PR TITLE
Add support to install or remove flows in the switches through events

### DIFF
--- a/main.py
+++ b/main.py
@@ -253,7 +253,7 @@ class Main(KytosNApp):
         return jsonify(switch_flows)
 
     @listen_to('kytos.flow_manager.flows.(install|delete)')
-    def event_add_flow(self, event):
+    def event_flows_install_delete(self, event):
         """Install or delete flows in the switches through events.
 
         Install or delete Flow of switches identified by dpid.
@@ -268,11 +268,14 @@ class Main(KytosNApp):
 
         if event.name == 'kytos.flow_manager.flows.install':
             command = 'add'
-        else:
+        elif event.name == 'kytos.flow_manager.flows.delete':
             command = 'delete'
+        else:
+            msg = f'Invalid event "{event.name}", should be install|delete'
+            raise ValueError(msg)
 
+        switch = self.controller.get_switch_by_dpid(dpid)
         try:
-            switch = self.controller.get_switch_by_dpid(dpid)
             self._install_flows(command, flow_dict, [switch])
         except InvalidCommandError as error:
             log.error("Error installing or deleting Flow through"

--- a/main.py
+++ b/main.py
@@ -252,6 +252,27 @@ class Main(KytosNApp):
 
         return jsonify(switch_flows)
 
+    @listen_to('kytos.flow_manager.flows.(install|delete)')
+    def event_add_flow(self, event):
+        """Install or delete flows in the switches through events.
+
+        Install or delete Flow of switches identified by dpid.
+        """
+        try:
+            dpid = event.content['dpid']
+            flow_dict = event.content['flow_dict']
+            command = event.content['command']
+        except KeyError as error:
+            log.error("Error getting fields to install or remove "
+                      f"Flows: {error}")
+            return
+        try:
+            switch = self.controller.get_switch_by_dpid(dpid)
+            self._install_flows(command, flow_dict, [switch])
+        except InvalidCommandError as error:
+            log.error("Error installing or deleting Flow through"
+                      f" Kytos Event: {error}")
+
     @rest('v2/flows', methods=['POST'])
     @rest('v2/flows/<dpid>', methods=['POST'])
     def add(self, dpid=None):

--- a/main.py
+++ b/main.py
@@ -261,11 +261,16 @@ class Main(KytosNApp):
         try:
             dpid = event.content['dpid']
             flow_dict = event.content['flow_dict']
-            command = event.content['command']
         except KeyError as error:
             log.error("Error getting fields to install or remove "
                       f"Flows: {error}")
             return
+
+        if event.name == 'kytos.flow_manager.flows.install':
+            command = 'add'
+        else:
+            command = 'delete'
+
         try:
             switch = self.controller.get_switch_by_dpid(dpid)
             self._install_flows(command, flow_dict, [switch])

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -196,7 +196,6 @@ class TestMain(TestCase):
         mock_flow_dict = MagicMock()
         event = get_kytos_event_mock(name='kytos.flow_manager.flows.install',
                                      content={'dpid': dpid,
-                                              'command': 'add',
                                               'flow_dict': mock_flow_dict})
         self.napp.event_add_flow(event)
         mock_install_flows.assert_called_with('add', mock_flow_dict, [switch])
@@ -210,7 +209,6 @@ class TestMain(TestCase):
         mock_flow_dict = MagicMock()
         event = get_kytos_event_mock(name='kytos.flow_manager.flows.delete',
                                      content={'dpid': dpid,
-                                              'command': 'delete',
                                               'flow_dict': mock_flow_dict})
         self.napp.event_add_flow(event)
         mock_install_flows.assert_called_with('delete', mock_flow_dict,

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -187,6 +187,35 @@ class TestMain(TestCase):
         mock_send_napp_event.assert_called_with(self.switch_01, flow,
                                                 'delete_strict')
 
+    @patch('napps.kytos.flow_manager.main.Main._install_flows')
+    def test_event_add_flow(self, mock_install_flows):
+        """Test method for installing flows on the switches through events."""
+        dpid = "00:00:00:00:00:00:00:01"
+        switch = get_switch_mock(dpid)
+        self.napp.controller.switches = {dpid: switch}
+        mock_flow_dict = MagicMock()
+        event = get_kytos_event_mock(name='kytos.flow_manager.flows.install',
+                                     content={'dpid': dpid,
+                                              'command': 'add',
+                                              'flow_dict': mock_flow_dict})
+        self.napp.event_add_flow(event)
+        mock_install_flows.assert_called_with('add', mock_flow_dict, [switch])
+
+    @patch('napps.kytos.flow_manager.main.Main._install_flows')
+    def test_event_add_flow_delete(self, mock_install_flows):
+        """Test method for removing flows on the switches through events."""
+        dpid = "00:00:00:00:00:00:00:01"
+        switch = get_switch_mock(dpid)
+        self.napp.controller.switches = {dpid: switch}
+        mock_flow_dict = MagicMock()
+        event = get_kytos_event_mock(name='kytos.flow_manager.flows.delete',
+                                     content={'dpid': dpid,
+                                              'command': 'delete',
+                                              'flow_dict': mock_flow_dict})
+        self.napp.event_add_flow(event)
+        mock_install_flows.assert_called_with('delete', mock_flow_dict,
+                                              [switch])
+
     def test_add_flow_mod_sent(self):
         """Test _add_flow_mod_sent method."""
         xid = 0

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -197,11 +197,11 @@ class TestMain(TestCase):
         event = get_kytos_event_mock(name='kytos.flow_manager.flows.install',
                                      content={'dpid': dpid,
                                               'flow_dict': mock_flow_dict})
-        self.napp.event_add_flow(event)
+        self.napp.event_flows_install_delete(event)
         mock_install_flows.assert_called_with('add', mock_flow_dict, [switch])
 
     @patch('napps.kytos.flow_manager.main.Main._install_flows')
-    def test_event_add_flow_delete(self, mock_install_flows):
+    def test_event_flows_install_delete(self, mock_install_flows):
         """Test method for removing flows on the switches through events."""
         dpid = "00:00:00:00:00:00:00:01"
         switch = get_switch_mock(dpid)
@@ -210,7 +210,7 @@ class TestMain(TestCase):
         event = get_kytos_event_mock(name='kytos.flow_manager.flows.delete',
                                      content={'dpid': dpid,
                                               'flow_dict': mock_flow_dict})
-        self.napp.event_add_flow(event)
+        self.napp.event_flows_install_delete(event)
         mock_install_flows.assert_called_with('delete', mock_flow_dict,
                                               [switch])
 


### PR DESCRIPTION
### :octocat: Are you working on some issue? Identify the issue!

Fix #104 

### :bookmark_tabs: Description of the Change

Add support to install and remove flows in the switches by `dpid` using kytos Events 
(`kytos.flow_manager.flows.(install|delete)`).

This pull request may allow replacement of the REST endpoint `of_lldp` NApp:
- https://github.com/kytos/of_lldp/blob/master/main.py#L135
- https://github.com/kytos/of_lldp/blob/master/main.py#L137

Suggestions of the changes after this pull request
------------------------------------------------------------------

Suggestion to replace the [#L135](https://github.com/kytos/of_lldp/blob/master/main.py#L135):

``` python
event_install = KytosEvent(name='kytos.flow_manager.flows.install',
                           content={'dpid': destination,
                           'flow_dict': data})
self.controller.buffers.app.put(event_install)
```

Replacing [L#137](https://github.com/kytos/of_lldp/blob/master/main.py#L137):

``` python
event_delete = KytosEvent(name='kytos.flow_manager.flows.delete',
                           content={'dpid': destination,
                           'flow_dict': data})
self.controller.buffers.app.put(event_delete)
```

### :computer: Verification Process

- Unit tests are still passing
- Manually checked.

### :page_facing_up: Release Notes

- Add support for install or remove flows in the switches using Kytos Events.
