### PR TITLE
Fix the HTTP status code returned when the switch is not found

### DIFF
--- a/main.py
+++ b/main.py
@@ -248,8 +248,7 @@ class Main(KytosNApp):
             switches = [self.controller.get_switch_by_dpid(dpid)]
 
             if not any(switches):
-                response = "Switch not found"
-                raise NotFound(response)
+                raise NotFound("Switch not found")
 
         switch_flows = {}
 

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from flask import jsonify, request
 from pyof.foundation.base import UBIntBase
 from pyof.v0x01.asynchronous.error_msg import BadActionCode
 from pyof.v0x01.common.phy_port import PortConfig
+from werkzeug.exceptions import NotFound
 
 from kytos.core import KytosEvent, KytosNApp, log, rest
 from kytos.core.helpers import listen_to
@@ -245,6 +246,10 @@ class Main(KytosNApp):
             switches = self.controller.switches.values()
         else:
             switches = [self.controller.get_switch_by_dpid(dpid)]
+
+            if not any(switches):
+                response = "Switch not found"
+                raise NotFound(response)
 
         switch_flows = {}
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -87,6 +87,16 @@ class TestMain(TestCase):
         self.assertEqual(response.json, expected)
         self.assertEqual(response.status_code, 200)
 
+    def test_list_flows_fail_case(self):
+        """Test the failure case to recover all flows from a switch by dpid.
+
+        Failure case: Switch not found.
+        """
+        api = get_test_client(self.napp.controller, self.napp)
+        url = f'{self.API_URL}/v2/flows/00:00:00:00:00:00:00:05'
+        response = api.get(url)
+        self.assertEqual(response.status_code, 404)
+
     @patch('napps.kytos.flow_manager.main.Main._install_flows')
     def test_rest_add_and_delete_without_dpid(self, mock_install_flows):
         """Test add and delete rest method without dpid."""


### PR DESCRIPTION
# Pull Request Template

Fix #131 


### :bookmark_tabs: Description of the Change

Now, when a user requests a flow and a switch (`dpid`) is not found,
the HTTP status code returned is 404 instead of 500.

### :computer: Verification Process

- Tested manually.
- Tested with unit test.

### :page_facing_up: Release Notes

- Fix the HTTP status code returned when the switch is not found, return 404 instead of 500
